### PR TITLE
Implement question tracking per block

### DIFF
--- a/index.html
+++ b/index.html
@@ -52,8 +52,8 @@
         </div>
 
         <div class="rest-options" id="rest-options" style="display: none;">
-            <h2>Tempo de Descanso</h2>
-            <p>Deseja fazer uma pausa antes do próximo bloco?</p>
+            <h2>Hora da Pausa</h2>
+            <p>Vamos dar uma pausa antes do próximo bloco?</p>
             <div class="rest-buttons">
                 <button id="rest-yes">Sim</button>
                 <button id="rest-no">Não</button>

--- a/script.js
+++ b/script.js
@@ -14,6 +14,9 @@ class Timer {
         this.totalRestTimeUsed = 0;
         this.totalRestTimeAvailable = this.restDuration * 60; // 60 minutos em segundos
         this.remainingRestTime = this.totalRestTimeAvailable;
+
+        // Array para armazenar o número de questões concluídas em cada bloco
+        this.questionsPerBlock = Array(this.totalBlocks).fill(0);
         
         // Inicializa o som do alarme
         this.alarmSound = new Audio('https://assets.mixkit.co/active_storage/sfx/2869/2869-preview.mp3');
@@ -165,6 +168,8 @@ class Timer {
         this.restOptionsElement.style.display = 'none';
         this.restTimerElement.style.display = 'none';
         this.stopAlarm(); // Para o alarme ao resetar
+        // Limpa as questões registradas
+        this.questionsPerBlock = Array(this.totalBlocks).fill(0);
         this.updateDisplay();
         this.updateProgress();
         this.updateBlocks();
@@ -200,10 +205,20 @@ class Timer {
         this.pauseButton.disabled = true;
         this.playAlarm(); // Toca o alarme ao terminar o bloco
 
+        // Solicita o número de questões feitas neste bloco
+        const resposta = prompt(`Quantas questões você completou no bloco ${this.currentBlock}?`, '0');
+        if (resposta !== null) {
+            const valor = parseInt(resposta);
+            if (!isNaN(valor)) {
+                this.questionsPerBlock[this.currentBlock - 1] = valor;
+            }
+        }
+
         if (this.currentBlock < this.totalBlocks) {
             this.showRestOptions();
         } else {
-            alert('Parabéns! Você completou todos os blocos!');
+            const totalQuestoes = this.questionsPerBlock.reduce((s, q) => s + q, 0);
+            alert(`Parabéns! Você completou todos os blocos!\nTotal de questões resolvidas: ${totalQuestoes}`);
             this.stopAlarm(); // Para o alarme após o alerta
             this.reset();
         }

--- a/script.js
+++ b/script.js
@@ -116,14 +116,14 @@ class Timer {
         this.updateBlocks();
         
         // Mostrar mensagem de confirmação
-        const confirmMessage = `Bloco ${blockNumber} selecionado. Os blocos anteriores serão marcados como concluídos.`;
+        const confirmMessage = `Bloco ${blockNumber} escolhido! Os anteriores serão marcados como concluídos. Bons estudos!`;
         alert(confirmMessage);
     }
 
     start() {
         if (this.isResting) {
             // Se estiver em descanso, interrompe o descanso
-            if (confirm('Deseja realmente interromper o tempo de descanso?')) {
+            if (confirm('Tem certeza de que deseja interromper a pausa agora?')) {
                 this.remainingRestTime += this.restTimeRemaining; // Devolve o tempo não usado
                 this.stopAlarm(); // Para o alarme ao interromper o descanso
                 this.finishRest();
@@ -206,7 +206,7 @@ class Timer {
         this.playAlarm(); // Toca o alarme ao terminar o bloco
 
         // Solicita o número de questões feitas neste bloco
-        const resposta = prompt(`Quantas questões você completou no bloco ${this.currentBlock}?`, '0');
+        const resposta = prompt(`Quantas questões você mandou bem no bloco ${this.currentBlock}?`, '0');
         if (resposta !== null) {
             const valor = parseInt(resposta);
             if (!isNaN(valor)) {
@@ -218,7 +218,7 @@ class Timer {
             this.showRestOptions();
         } else {
             const totalQuestoes = this.questionsPerBlock.reduce((s, q) => s + q, 0);
-            alert(`Parabéns! Você completou todos os blocos!\nTotal de questões resolvidas: ${totalQuestoes}`);
+            alert(`Missão cumprida! Todos os blocos finalizados.\nVocê resolveu ${totalQuestoes} questões!`);
             this.stopAlarm(); // Para o alarme após o alerta
             this.reset();
         }


### PR DESCRIPTION
## Summary
- store question counts for each study block
- prompt for questions solved after each block and show total at the end

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_684076a902ac8330866bad5219ac509f